### PR TITLE
Fix MJS issues

### DIFF
--- a/fix-extns-mjs
+++ b/fix-extns-mjs
@@ -1,0 +1,6 @@
+# local files
+sed --in-place 's/\(from "\.\/.\+\)";$/\1.mjs";/g' dist/*.mjs
+
+# next/* packages
+sed --in-place 's/\(from "next\/.\+\)";$/\1.js";/g' dist/*.mjs
+

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "types": "rimraf --glob dist/*.{d.ts,d.ts.map} dist/**/*.{d.ts,d.ts.map} && tsc --emitDeclarationOnly && tsc-alias",
-    "build": "rimraf --glob dist/*.{js,js.map,mjs,mjs.map} && tsup"
+    "build": "rimraf --glob dist/*.{js,js.map,mjs,mjs.map} && tsup && sed --in-place 's/\\(from \"\\.\\/.\\+\\)\";$/\\1.mjs\";/g' dist/*.mjs"
   },
   "peerDependencies": {
     "next": ">= 13.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "types": "rimraf --glob dist/*.{d.ts,d.ts.map} dist/**/*.{d.ts,d.ts.map} && tsc --emitDeclarationOnly && tsc-alias",
-    "build": "rimraf --glob dist/*.{js,js.map,mjs,mjs.map} && tsup && sed --in-place 's/\\(from \"\\.\\/.\\+\\)\";$/\\1.mjs\";/g' dist/*.mjs"
+    "build": "rimraf --glob dist/*.{js,js.map,mjs,mjs.map} && tsup && ./fix-extns-mjs"
   },
   "peerDependencies": {
     "next": ">= 13.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 'use client';
 
-export * from './types';
+export type * from './types';
 export * from './hook';
 export * from './provider';


### PR DESCRIPTION
Thanks for the library. This PR fixes ~two~ three issues I was encountering:

- the Next bundler couldn't understand the `types.mjs` file since it didn't `export` anything; changing to `export type *` removes this export from the emitted JS
- adds `.mjs` extensions to imports as required by ESM (somehow my code was loading both the ESM and CJS versions, and then complaining that it couldn't find `<CookiesProvider>`)
- rewrite `import { /* ... */ } from "next/navigation"` to `import { /* ... */ } from "next/navigation.js"`

Your original code was working for me at one point, so I don't know why it suddenly started breaking, and I wasn't able to put together a minimal repro. These are all how ESM is supposed to work though.